### PR TITLE
Fix version banner to top of page and remove "click here"

### DIFF
--- a/_includes/version-banner.html
+++ b/_includes/version-banner.html
@@ -1,6 +1,6 @@
 {% if site.git_branch and site.git_branch != "master" %}
 <div class="version-banner">
-  Hey, you're viewing the <strong>{{ site.git_branch }}</strong> version of this page!
-  Click <a href="{{site.baseurl_orig}}{{ page.url }}">here</a> to view the current (stable) version.
+    Hey, you're viewing the <strong>{{ site.git_branch }}</strong> version of this page!
+    <a href="{{site.baseurl_orig}}{{ page.url }}">View the current version instead.</a>
 </div>
 {% endif %}

--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -9,8 +9,9 @@
 
     {% include googletagmanager.html %}
 
+    {% include version-banner.html %}
+
     <div class="container">
-      {% include version-banner.html %}
 
       {% include header.html %}
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -21,6 +21,15 @@ body {
     color: $text-color;
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;
+
+    // Make some space for the version banner
+    @if $branch != "" and $branch != "master" {
+      padding-top: 36px;
+
+      @include media-query($on-palm) {
+          padding-top: 61px;
+      }
+    }
 }
 
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,7 +2,7 @@
  * Site header
  */
 .site-header {
-    border-top: 5px solid $grey-color-dark;
+    /*border-top: 5px solid $grey-color-dark;*/
     border-bottom: 1px solid $grey-color-light;
     min-height: 56px;
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -296,7 +296,10 @@
  */
 
 .version-banner {
-  // width: 100%;
+  position: fixed;
+  top: 0px;
+  width: 100%;
+  z-index: 1000000;
   text-align: center;
   background-color: #424242;
   padding: 5px;
@@ -304,7 +307,8 @@
   font-style: italic;
 }
 
-.version-banner a {
-  color: white;
-  text-decoration: underline;
+.version-banner a,
+.version-banner a:hover,
+.version-banner a:visited {
+  color: lighten($brand-color, 25%);
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -50,6 +50,7 @@ $on-laptop:        800px;
    }  
 }
 
+$branch: "{{ site.git_branch }}"; // used to pad body if version banner exists
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import


### PR DESCRIPTION
@dbelcher, @golsby: Please see http://developer.rhino3d.com/demo/

<img width="1352" alt="screen shot 2016-05-10 at 12 37 19" src="https://cloud.githubusercontent.com/assets/121068/15145170/f83352e6-16ab-11e6-82a4-db043f9f937d.png">

Code attached but I might do a _ninja_ merge into both `master` and `wip`...