### PR TITLE
Change in JSON make parking object as dict from office

### DIFF
--- a/_guide_topics/rhinopython/python-xml-json.md
+++ b/_guide_topics/rhinopython/python-xml-json.md
@@ -46,12 +46,13 @@ Here is an example of a JSON structure describing a medical office, taken from a
         "sq-ft": 150,
         "price": 100
       }
-    ]},
+    ],
     "parking": {
       "location": "premium",
       "style": "covered",
       "price": 750
     }
+  }
 } 
 ```
 It is this dictionary setup that works best for Json.


### PR DESCRIPTION
The line 119 print datastore["office"]["parking"]["style"] fails, this fix will fix the input JSON object and make it consistent with the 'Dictionary as a Database Guide'.

Hi Scott and others, excellent docs and examples. Thanks for the information.